### PR TITLE
Let dependency managers set the load paths properly

### DIFF
--- a/lib/sequel-vertica.rb
+++ b/lib/sequel-vertica.rb
@@ -1,4 +1,4 @@
 require 'sequel-vertica/version'
-require './lib/sequel/adapters/vertica'
+require 'sequel/adapters/vertica'
 
 Sequel::Database::ADAPTERS << 'vertica'


### PR DESCRIPTION
The relative require is not working when the current directory is set to an unexpected value.

Fix: do not use relative requires, and let dependency managers (bundler) set the load path properly.
