### PR TITLE
Turn a Vertica error into a Sequel error

### DIFF
--- a/lib/sequel/adapters/vertica.rb
+++ b/lib/sequel/adapters/vertica.rb
@@ -24,6 +24,8 @@ module Sequel
           res = conn.query(sql)
           res.each(&block)
         end
+      rescue ::Vertica::Error => e
+        raise_error(e)
       end
 
       def execute_insert(sql, opts = {}, &block)


### PR DESCRIPTION
So Sequel knows how to deal with it properly.

This is required for `table_exists?`
