### PR TITLE
Fixed issue with auto incrementing primary key

### DIFF
--- a/lib/sequel/adapters/vertica.rb
+++ b/lib/sequel/adapters/vertica.rb
@@ -2,9 +2,24 @@ require 'vertica'
 
 module Sequel
   module Vertica
+
+    class CreateTableGenerator < Sequel::Schema::CreateTableGenerator
+      def primary_key(name, *args)
+        super
+
+        if @primary_key[:auto_increment]
+          @primary_key.delete(:auto_increment)
+          @primary_key[:type] = Vertica::Database::AUTO_INCREMENT
+        end
+
+        @primary_key
+      end
+    end
+
     class Database < Sequel::Database
       ::Vertica::Connection.send(:alias_method,:execute, :query)
       PK_NAME = 'C_PRIMARY'
+      AUTO_INCREMENT = 'AUTO_INCREMENT'
       set_adapter_scheme :vertica
 
       def connect(server)
@@ -59,6 +74,14 @@ module Sequel
 
       def locks
         dataset.from(:v_monitor__locks)
+      end
+
+      def auto_increment_sql
+        AUTO_INCREMENT
+      end
+
+      def create_table_generator_class
+        Vertica::CreateTableGenerator
       end
 
       def tables(options = {} )

--- a/spec/adapters/vertica_spec.rb
+++ b/spec/adapters/vertica_spec.rb
@@ -45,6 +45,16 @@ describe "A Vertica database" do
     ]
   end
 
+  specify "should create an auto incrementing primary key" do
+    @db.create_table! :auto_inc_test do
+      primary_key :id
+      integer :value
+    end
+    @db[<<-SQL].first[:COUNT].should == 1
+      SELECT COUNT(1) FROM v_catalog.sequences WHERE identity_table_name='auto_inc_test'
+    SQL
+  end
+
 end
 
 describe "A vertica dataset" do


### PR DESCRIPTION
Fixed an issue where creating a table with a column identified with `primary_key` would result in an SQL error. Reason being that vertica requires the type of an auto incrementing column to be `AUTO_INCREMENT` and not a data type. `AUTO_INCREMENT` also needs to have a underline between `AUTO` and `INCREMENT` which is not the default syntax that sequel used. 

For example the following create would fail

```
@db.create_table(:foo) do
  primary_key :id
  Integer :bar
end
```

This pr should correct the problem.
