### PR TITLE
Support the `COPY` command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'http://rubygems.org'
 
 # Specify your gem's dependencies in sequel-vertica.gemspec
 gemspec
+
+group :development do
+  gem 'debugger'
+end

--- a/sequel-vertica.gemspec
+++ b/sequel-vertica.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
 
   gem.requirements  = "Vertica version 6.0 or higher"
 
-  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec", "~> 2.14.1"
   gem.add_runtime_dependency "sequel", "~> 3.45.0"
   gem.add_runtime_dependency "vertica", "~> 0.11.0"
 

--- a/sequel-vertica.gemspec
+++ b/sequel-vertica.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rspec", "~> 2.14.1"
   gem.add_runtime_dependency "sequel", "~> 3.45.0"
-  gem.add_runtime_dependency "vertica", "~> 0.11.0"
+  gem.add_runtime_dependency "vertica", "~> 0.11.1"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Lifted from https://github.com/jeremyevans/sequel/blob/master/lib/sequel/adapters/postgres.rb#L375-L405 where most of the exception handling is now done in https://github.com/sprsquish/vertica/pull/18.

I plan to get the stuff in the vertica gem out instead of this gemfile hack which only temporarily works for development before merging. 

Thoughts?