### PR TITLE
updated to work with most recent sequel gem (4.9.0)

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--color --format doc

--- a/lib/sequel/adapters/vertica.rb
+++ b/lib/sequel/adapters/vertica.rb
@@ -1,6 +1,7 @@
 require 'vertica'
 
 module Sequel
+  extension :core_extensions
   module Vertica
 
     class CreateTableGenerator < Sequel::Schema::CreateTableGenerator
@@ -102,7 +103,7 @@ module Sequel
       def schema_parse_table(table_name, options = {})
         schema = options[:schema]
 
-        selector = [:column_name, :constraint_name, :is_nullable.as(:allow_null), 
+        selector = [:column_name, :constraint_name, :is_nullable.as(:allow_null),
                     (:column_default).as(:default), (:data_type).as(:db_type)]
         filter = { :columns__table_name => table_name }
         filter[:columns__table_schema] = schema.to_s if schema
@@ -126,7 +127,7 @@ module Sequel
       Database::DatasetClass = self
       EXPLAIN = 'EXPLAIN '
       EXPLAIN_LOCAL = 'EXPLAIN LOCAL '
-      QUERY_PLAN = 'QUERY PLAN' 
+      QUERY_PLAN = 'QUERY PLAN'
 
       def columns
         return @columns if @columns
@@ -137,8 +138,8 @@ module Sequel
       end
 
       def fetch_rows(sql)
-        execute(sql) do |row| 
-          yield row 
+        execute(sql) do |row|
+          yield row
         end
       end
 

--- a/sequel-vertica.gemspec
+++ b/sequel-vertica.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.requirements  = "Vertica version 6.0 or higher"
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_runtime_dependency "sequel", "~> 3.45.0"
+  gem.add_runtime_dependency "sequel", "~> 4.9.0"
   gem.add_runtime_dependency "vertica", "~> 0.11.0"
 
   gem.add_development_dependency "rake", ">= 10"

--- a/spec/adapters/vertica_spec.rb
+++ b/spec/adapters/vertica_spec.rb
@@ -28,7 +28,7 @@ VERTICA_DB.create_table! :test4 do
   bytea :value
 end
 
-describe "A Vertica database" do 
+describe "A Vertica database" do
 
   before do
     @db = VERTICA_DB
@@ -67,7 +67,7 @@ describe "A vertica dataset" do
     @d.select(:name).sql.should == \
       'SELECT "name" FROM "test"'
 
-    @d.select('COUNT(*)'.lit).sql.should == \
+    @d.select(Sequel.lit('COUNT(*)')).sql.should == \
       'SELECT COUNT(*) FROM "test"'
 
     @d.select(:max.sql_function(:value)).sql.should == \
@@ -82,13 +82,13 @@ describe "A vertica dataset" do
     @d.order(:name.desc).sql.should == \
       'SELECT * FROM "test" ORDER BY "name" DESC'
 
-    @d.select('test.name AS item_name'.lit).sql.should == \
+    @d.select(Sequel.lit('test.name AS item_name')).sql.should == \
       'SELECT test.name AS item_name FROM "test"'
 
-    @d.select('"name"'.lit).sql.should == \
+    @d.select(Sequel.lit('"name"')).sql.should == \
       'SELECT "name" FROM "test"'
 
-    @d.select('max(test."name") AS "max_name"'.lit).sql.should == \
+    @d.select(Sequel.lit('max(test."name") AS "max_name"')).sql.should == \
       'SELECT max(test."name") AS "max_name" FROM "test"'
 
     @d.insert_sql(:x => :y).should =~ \
@@ -239,7 +239,6 @@ describe "Vertica::Database schema qualified tables" do
 
   after do
     VERTICA_DB << "DROP SCHEMA schema_test CASCADE"
-    VERTICA_DB.default_schema = nil
   end
 
   specify "should be able to create, drop, select and insert into tables in a given schema" do
@@ -247,11 +246,11 @@ describe "Vertica::Database schema qualified tables" do
     VERTICA_DB[:schema_test__table_in_schema_test].first.should == nil
     VERTICA_DB[:schema_test__table_in_schema_test].insert(:i=>1).should == 1
     VERTICA_DB[:schema_test__table_in_schema_test].first.should == {:i=>1}
-    VERTICA_DB.from('schema_test.table_in_schema_test'.lit).first.should == {:i=>1}
+    VERTICA_DB.from(Sequel.lit('schema_test.table_in_schema_test')).first.should == {:i=>1}
     VERTICA_DB.drop_table(:schema_test__table_in_schema_test)
     VERTICA_DB.create_table(:table_in_schema_test.qualify(:schema_test)){integer :i}
     VERTICA_DB[:schema_test__table_in_schema_test].first.should == nil
-    VERTICA_DB.from('schema_test.table_in_schema_test'.lit).first.should == nil
+    VERTICA_DB.from(Sequel.lit('schema_test.table_in_schema_test')).first.should == nil
     VERTICA_DB.drop_table(:table_in_schema_test.qualify(:schema_test))
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ if ENV['SEQUEL_COLUMNS_INTROSPECTION']
 end
 
 
-Sequel::Model.cache_anonymous_models = false
+Sequel.cache_anonymous_models = false
 
 class Sequel::Database
   def log_duration(duration, message)
@@ -24,14 +24,14 @@ class Sequel::Database
 end
 
 (defined?(RSpec) ? RSpec::Core::ExampleGroup : Spec::Example::ExampleGroup).class_eval do
-  def log 
+  def log
     begin
       INTEGRATION_DB.loggers << Logger.new(STDOUT)
       yield
     ensure
       INTEGRATION_DB.loggers.pop
-    end 
-  end 
+    end
+  end
 
   def self.cspecify(message, *checked, &block)
     return specify(message, &block) if ENV['SEQUEL_NO_PENDING']


### PR DESCRIPTION
The work for this was pretty minor:
1. Change String#lit to Sequel#lit
2. Remove Database#default_schema= nil from spec (default_schema has been removed from Sequel)
3. Give the fully qualified name of for table_name in a join (lib/sequel/adapters/vertica.rb:106)
4. Add :core_extensions, since the methods #as et. al were moved out of Sequel::Core a while back
5. Sequel::Model.cache_anonymous_models = false --> Sequel.cache_anonymous_models = false

All and all, the while pull request is only a few lines of changes (plus killing some bonus whitespace)
