### PR TITLE
Add #timeseries to Sequel::Vertica::Dataset

### DIFF
--- a/lib/sequel-vertica/version.rb
+++ b/lib/sequel-vertica/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   module Vertica
-    VERSION = "0.2.1"
+    VERSION = "0.3.0"
   end
 end

--- a/lib/sequel/adapters/vertica.rb
+++ b/lib/sequel/adapters/vertica.rb
@@ -136,9 +136,9 @@ module Sequel
       Dataset.def_sql_method(self, :select, %w(with select distinct columns from join timeseries where group having compounds order limit lock))
 
       def timeseries(opts={})
-        fail "timeseries requires :alias" unless opts[:alias]
-        fail "timeseries requires :time_unit" unless opts[:time_unit]
-        fail "timeseries requires an :over clause" unless opts[:over]
+        raise ArgumentError, "timeseries requires :alias" unless opts[:alias]
+        raise ArgumentError, "timeseries requires :time_unit" unless opts[:time_unit]
+        raise ArgumentError, "timeseries requires an :over clause" unless opts[:over]
 
         clone(timeseries: {
                 alias: opts[:alias],

--- a/lib/sequel/adapters/vertica.rb
+++ b/lib/sequel/adapters/vertica.rb
@@ -126,9 +126,33 @@ module Sequel
 
     class Dataset < Sequel::Dataset
       Database::DatasetClass = self
-      EXPLAIN = 'EXPLAIN '
-      EXPLAIN_LOCAL = 'EXPLAIN LOCAL '
-      QUERY_PLAN = 'QUERY PLAN'
+      EXPLAIN = 'EXPLAIN '.freeze
+      EXPLAIN_LOCAL = 'EXPLAIN LOCAL '.freeze
+      QUERY_PLAN = 'QUERY PLAN'.freeze
+      TIMESERIES = ' TIMESERIES '.freeze
+      OVER = ' OVER '.freeze
+      AS = ' AS '.freeze
+
+      Dataset.def_sql_method(self, :select, %w(with select distinct columns from join timeseries where group having compounds order limit lock))
+
+      def timeseries(opts={})
+        fail "timeseries requires :alias" unless opts[:alias]
+        fail "timeseries requires :time_unit" unless opts[:time_unit]
+        fail "timeseries requires an :over clause" unless opts[:over]
+
+        clone(timeseries: {
+                alias: opts[:alias],
+                time_unit: opts[:time_unit],
+                over: Sequel::SQL::Window.new(opts[:over])
+              })
+      end
+
+      def select_timeseries_sql(sql)
+        if ts_opts = opts[:timeseries]
+          sql << TIMESERIES << ts_opts[:alias].to_s << AS << "'#{ts_opts[:time_unit]}'" << OVER
+          window_sql_append(sql, ts_opts[:over].opts)
+        end
+      end
 
       def columns
         return @columns if @columns
@@ -149,6 +173,10 @@ module Sequel
       end
 
       def supports_regexp?
+        true
+      end
+
+      def supports_window_functions?
         true
       end
     end

--- a/spec/adapters/vertica_spec.rb
+++ b/spec/adapters/vertica_spec.rb
@@ -177,7 +177,7 @@ describe "A Vertica dataset with a timestamp field" do
   end
 
   describe "Verticas's EXPLAIN and EXPLAIN LOCAL" do
-    specify "do not raise errors" do
+    specify "should not raise errors" do
       @d = VERTICA_DB[:test3]
       expect{@d.explain}.not_to raise_error
       expect{@d.explain(:local => true)}.not_to raise_error
@@ -195,7 +195,7 @@ describe "A Vertica dataset with a timestamp field" do
     [:alias, :time_unit, :over].each do |option|
       specify "requires #{option}" do
         expect { @d.timeseries(timeseries_opts.reject { |k,v| k == option }) }.to \
-          raise_error(RuntimeError, /timeseries requires.*#{option}/)
+          raise_error(ArgumentError, /timeseries requires.*#{option}/)
       end
     end
 


### PR DESCRIPTION
Sequel::Vertica::Dataset#timeseries takes the following options (all required):
* :alias     => The alias for the time series
* :time_unit => The unit of time of slice computation--
                how long is the timeseries interval, in other words.
* :over      => Specifies partitioning and ordering for the time series.

Example:

DB.from(:foo).select_all.timeseries(alias: :slice_time, time_unit: '1 minute', over: { order: :occurred_at })

At this time, #timeseries does not accept an ORDER BY clause outside of the
:over option, though that is supported by vertica. This is purely driven by
personal need-- I don't need it right now. If you do, feel free to submit a
PR!