### PR TITLE
added support for ILIKE and NOT ILIKE operators

### DIFF
--- a/lib/sequel/adapters/vertica.rb
+++ b/lib/sequel/adapters/vertica.rb
@@ -132,6 +132,11 @@ module Sequel
       TIMESERIES = ' TIMESERIES '.freeze
       OVER = ' OVER '.freeze
       AS = ' AS '.freeze
+      SPACE = Dataset::SPACE
+      PAREN_OPEN = Dataset::PAREN_OPEN
+      PAREN_CLOSE = Dataset::PAREN_CLOSE
+      ESCAPE = Dataset::ESCAPE
+      BACKSLASH = Dataset::BACKSLASH
 
       Dataset.def_sql_method(self, :select, %w(with select distinct columns from join timeseries where group having compounds order limit lock))
 
@@ -178,6 +183,22 @@ module Sequel
 
       def supports_window_functions?
         true
+      end
+
+      # Use the ILIKE and NOT ILIKE operators.
+      def complex_expression_sql_append(sql, op, args)
+        case op
+          when :ILIKE, :'NOT ILIKE'
+            sql << PAREN_OPEN
+            literal_append(sql, args.at(0))
+            sql << SPACE << op.to_s << SPACE
+            literal_append(sql, args.at(1))
+            sql << ESCAPE
+            literal_append(sql, BACKSLASH)
+            sql << PAREN_CLOSE
+          else
+            super
+        end
       end
     end
   end

--- a/spec/adapters/vertica_spec.rb
+++ b/spec/adapters/vertica_spec.rb
@@ -141,6 +141,11 @@ describe "A vertica dataset" do
     expect(@d.filter(:name => /^bc/).count).to eq(1)
   end
 
+  specify "should support ilike operator" do
+    expect(@d.where(Sequel.ilike(:name, '%acme%')).sql).to eq(%{SELECT * FROM "test" WHERE ("name" ILIKE '%acme%' ESCAPE '\\')})
+    expect(@d.where(~Sequel.ilike(:name, '%acme%')).sql).to eq(%{SELECT * FROM "test" WHERE ("name" NOT ILIKE '%acme%' ESCAPE '\\')})
+  end
+
   specify "#columns returns the correct column names" do
     expect(@d.columns!).to eq([:name, :value])
     expect(@d.select(:name).columns!).to eq([:name])


### PR DESCRIPTION
Sometimes Vertica complains about UPPER(str) LIKE UPPER('%str%') when comparing longer strings.  Vertica does however support ILIKE just like PostgreSQL and does not complain when comparing longer strings.  

This PR adds support for ILIKE and NOT ILIKE