### PR TITLE
Update To Support Sequel 4.49+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 .bundle
+.byebug_history
 .config
 .yardoc
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'http://rubygems.org'
 
 # Specify your gem's dependencies in sequel-vertica.gemspec
 gemspec
-
-gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'http://rubygems.org'
 
 # Specify your gem's dependencies in sequel-vertica.gemspec
 gemspec
+
+gem 'byebug'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sequel-vertica [![Build Status](https://travis-ci.org/camilo/sequel-vertica.svg?branch=travis)](https://travis-ci.org/camilo/sequel-vertica)
+# Sequel-vertica [![Build Status](https://travis-ci.org/camilo/sequel-vertica.svg?branch=master)](https://travis-ci.org/camilo/sequel-vertica)
 
 A third party adapter to use Vertica through sequel, most of the actual work is
 done by sequel and the vertica gem.

--- a/lib/sequel/adapters/vertica.rb
+++ b/lib/sequel/adapters/vertica.rb
@@ -41,7 +41,7 @@ module Sequel
       def execute(sql, opts = {}, &block)
         res = nil
         synchronize(opts[:server]) do |conn|
-          res = log_yield(sql) { conn.query(sql) }
+          res = log_connection_yield(sql, self, opts) { conn.query(sql) }
           res.each(&block)
         end
         res
@@ -131,7 +131,7 @@ module Sequel
       end
 
       def locks
-        dataset.from(:v_monitor__locks)
+        dataset.from(Sequel[:v_monitor][:locks])
       end
 
       def auto_increment_sql
@@ -148,7 +148,7 @@ module Sequel
         filter[:table_schema] = schema.to_s if schema
 
         dataset.select(:table_name).
-          from(:v_catalog__tables).
+          from(Sequel[:v_catalog][:tables]).
           filter(filter).
           to_a.
           map { |h| h[:table_name].to_sym }
@@ -159,14 +159,14 @@ module Sequel
 
         selector = [:column_name, :constraint_name, :is_nullable.as(:allow_null),
                     (:column_default).as(:default), (:data_type).as(:db_type)]
-        filter = { :columns__table_name => table_name.to_s }
-        filter[:columns__table_schema] = schema.to_s if schema
+        filter = { Sequel[:columns][:table_name] => table_name.to_s }
+        filter[Sequel[:columns][:table_schema]] = schema.to_s if schema
 
         dataset = metadata_dataset.
           select(*selector).
           filter(filter).
-          from(:v_catalog__columns).
-          left_outer_join(:v_catalog__table_constraints, :table_id => :table_id)
+          from(Sequel[:v_catalog][:columns]).
+          left_outer_join(Sequel[:v_catalog][:table_constraints], :table_id => :table_id)
 
         dataset.map do |row|
           row[:default] = nil if blank_object?(row[:default])
@@ -188,6 +188,10 @@ module Sequel
         end
         sql
       end
+
+      def dataset_class_default
+        Dataset
+      end
     end
 
     class Dataset < Sequel::Dataset
@@ -199,11 +203,11 @@ module Sequel
       OVER = ' OVER '.freeze
       AS = ' AS '.freeze
       REGEXP_LIKE = 'REGEXP_LIKE'.freeze
-      SPACE = Dataset::SPACE
-      PAREN_OPEN = Dataset::PAREN_OPEN
-      PAREN_CLOSE = Dataset::PAREN_CLOSE
-      ESCAPE = Dataset::ESCAPE
-      BACKSLASH = Dataset::BACKSLASH
+      SPACE = ' '.freeze
+      PAREN_OPEN = '('.freeze
+      PAREN_CLOSE = ')'.freeze
+      ESCAPE = ' ESCAPE '.freeze
+      BACKSLASH = '\\'.freeze
 
       Dataset.def_sql_method(self, :select, %w(with select distinct columns from join timeseries where group having compounds order limit lock))
 
@@ -226,16 +230,10 @@ module Sequel
         end
       end
 
-      def columns
-        return @columns if @columns
-        ds = unfiltered.unordered.clone(:distinct => nil, :limit => 0, :offset => nil)
-        res = @db.execute(ds.select_sql)
-        @columns = res.columns.map { |c| c.name.to_sym }
-        @columns
-      end
-
       def fetch_rows(sql)
-        execute(sql) do |row|
+        result_set = execute(sql)
+        self.columns = result_set.columns.map { |c| c.name.to_sym }
+        result_set.each do |row|
           yield row.to_h.inject({}) { |a, (k,v)| a[k.to_sym] = v; a }
         end
       end

--- a/sequel-vertica.gemspec
+++ b/sequel-vertica.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_runtime_dependency "sequel", "~> 4.14"
-  gem.add_runtime_dependency "vertica", "~> 0.11.1"
+  gem.add_runtime_dependency "vertica", "~> 1.0"
 
   gem.add_development_dependency "rake", ">= 10"
   gem.add_development_dependency "rspec" , "~> 3.1"

--- a/sequel-vertica.gemspec
+++ b/sequel-vertica.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/camilo/sequel-vertica"
   gem.license     = "MIT"
 
-  gem.requirements  = "Vertica version 6.0 or higher"
+  gem.requirements  = "Vertica version 8.1 or higher"
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_runtime_dependency "sequel", "~> 4.14"
+  gem.add_runtime_dependency "sequel", "~> 4.49"
   gem.add_runtime_dependency "vertica", "~> 1.0"
 
   gem.add_development_dependency "rake", ">= 10"

--- a/spec/adapters/vertica_spec.rb
+++ b/spec/adapters/vertica_spec.rb
@@ -89,7 +89,7 @@ describe "A vertica dataset" do
     'SELECT NOW() FROM "test"'
     )
 
-    expect(@d.select(:max.sql_function(:items__value)).sql).to eq( \
+    expect(@d.select(:max.sql_function(Sequel[:items][:value])).sql).to eq( \
       'SELECT max("items"."value") FROM "test"'
     )
 
@@ -343,20 +343,20 @@ describe "Vertica::Database schema qualified tables" do
   end
 
   specify "should be able to create, drop, select and insert into tables in a given schema" do
-    VERTICA_DB.create_table(:schema_test__table_in_schema_test){integer :i}
-    expect(VERTICA_DB[:schema_test__table_in_schema_test].first).to eq(nil)
-    expect(VERTICA_DB[:schema_test__table_in_schema_test].insert(:i=>1)).to eq(1)
-    expect(VERTICA_DB[:schema_test__table_in_schema_test].first).to eq({:i=>1})
+    VERTICA_DB.create_table(Sequel[:schema_test][:table_in_schema_test]){integer :i}
+    expect(VERTICA_DB[Sequel[:schema_test][:table_in_schema_test]].first).to eq(nil)
+    expect(VERTICA_DB[Sequel[:schema_test][:table_in_schema_test]].insert(:i=>1)).to eq(1)
+    expect(VERTICA_DB[Sequel[:schema_test][:table_in_schema_test]].first).to eq({:i=>1})
     expect(VERTICA_DB.from(Sequel.lit('schema_test.table_in_schema_test')).first).to eq({:i=>1})
-    VERTICA_DB.drop_table(:schema_test__table_in_schema_test)
+    VERTICA_DB.drop_table(Sequel[:schema_test][:table_in_schema_test])
     VERTICA_DB.create_table(:table_in_schema_test.qualify(:schema_test)){integer :i}
-    expect(VERTICA_DB[:schema_test__table_in_schema_test].first).to eq(nil)
+    expect(VERTICA_DB[Sequel[:schema_test][:table_in_schema_test]].first).to eq(nil)
     expect(VERTICA_DB.from(Sequel.lit('schema_test.table_in_schema_test')).first).to eq(nil)
     VERTICA_DB.drop_table(:table_in_schema_test.qualify(:schema_test))
   end
 
   specify "#tables should not include tables in a default non-public schema" do
-    VERTICA_DB.create_table(:schema_test__table_in_schema_test){integer :i}
+    VERTICA_DB.create_table(Sequel[:schema_test][:table_in_schema_test]){integer :i}
     expect(VERTICA_DB.tables).to include(:table_in_schema_test)
     expect(VERTICA_DB.tables).not_to include(:tables)
     expect(VERTICA_DB.tables).not_to include(:columns)
@@ -365,12 +365,12 @@ describe "Vertica::Database schema qualified tables" do
   end
 
   specify "#tables should return tables in the schema provided by the :schema argument" do
-    VERTICA_DB.create_table(:schema_test__table_in_schema_test){integer :i}
+    VERTICA_DB.create_table(Sequel[:schema_test][:table_in_schema_test]){integer :i}
     expect(VERTICA_DB.tables(:schema=>:schema_test)).to eq([:table_in_schema_test])
   end
 
   specify "#schema should not include columns from tables in a default non-public schema" do
-    VERTICA_DB.create_table(:schema_test__domains){integer :i}
+    VERTICA_DB.create_table(Sequel[:schema_test][:domains]){integer :i}
     sch = VERTICA_DB.schema(:domains)
     cs = sch.map{|x| x.first}
     expect(cs).to include(:i)
@@ -379,7 +379,7 @@ describe "Vertica::Database schema qualified tables" do
 
   specify "#schema should only include columns from the table in the given :schema argument" do
     VERTICA_DB.create_table!(:domains){integer :d}
-    VERTICA_DB.create_table(:schema_test__domains){integer :i}
+    VERTICA_DB.create_table(Sequel[:schema_test][:domains]){integer :i}
     sch = VERTICA_DB.schema(:domains, :schema=>:schema_test)
     cs = sch.map{|x| x.first}
     expect(cs).to include(:i)
@@ -388,8 +388,8 @@ describe "Vertica::Database schema qualified tables" do
   end
 
   specify "#table_exists? should see if the table is in a given schema" do
-    VERTICA_DB.create_table(:schema_test__schema_test){integer :i}
-    expect(VERTICA_DB.table_exists?(:schema_test__schema_test)).to eq(true)
+    VERTICA_DB.create_table(Sequel[:schema_test][:schema_test]){integer :i}
+    expect(VERTICA_DB.table_exists?(Sequel[:schema_test][:schema_test])).to eq(true)
   end
 
 end

--- a/spec/adapters/vertica_spec.rb
+++ b/spec/adapters/vertica_spec.rb
@@ -146,12 +146,19 @@ describe "A vertica dataset" do
     expect(@d.where(~Sequel.ilike(:name, '%acme%')).sql).to eq(%{SELECT * FROM "test" WHERE ("name" NOT ILIKE '%acme%' ESCAPE '\\')})
   end
 
+  specify "supports case-insensitive regexps" do
+    @d << {:name => 'abc', :value => 1}
+    @d << {:name => 'bcd', :value => 2}
+
+    expect(@d.filter(:name => /BC/i).count).to eq(2)
+    expect(@d.filter(:name => /^BC/i).count).to eq(1)
+  end
+
   specify "#columns returns the correct column names" do
     expect(@d.columns!).to eq([:name, :value])
     expect(@d.select(:name).columns!).to eq([:name])
   end
 end
-
 
 describe "A Vertica dataset with a timestamp field" do
   before do
@@ -212,7 +219,6 @@ describe "A Vertica dataset with a timestamp field" do
   end
 end
 
-
 describe "A Vertica database" do
   before do
     @db = VERTICA_DB
@@ -252,6 +258,50 @@ describe "A Vertica database" do
   specify "#locks should be a dataset returning database locks " do
     expect(@db.locks).to be_a_kind_of(Sequel::Dataset)
     expect(@db.locks.all).to be_a_kind_of(Array)
+  end
+end
+
+describe "Vertica::Database#copy_into" do
+  before do
+    @db = VERTICA_DB
+    @db[:test].truncate
+  end
+
+  specify "takes data in an enumerable passed in with :data" do
+    strings = ["firstname|1"]
+    @db.copy_into(:test, data: strings)
+    expect(@db[:test].all.first.to_h).to eq({name: "firstname", value: 1})
+  end
+
+  specify "takes data from a block" do
+    strings = ["firstname|1"]
+    @db.copy_into(:test) {
+      strings.pop
+    }
+    expect(@db[:test].all.first.to_h).to eq({name: "firstname", value: 1})
+  end
+
+  specify "errors if both a block and :data are specified" do
+    expect { @db.copy_into(:test, data: ["a string"]) { "a block" } }.to raise_error(ArgumentError)
+  end
+
+  specify "errors if neither block nor :data are specified" do
+    expect { @db.copy_into(:test) }.to raise_error(ArgumentError)
+  end
+
+  specify "allows data columns to be specified" do
+    @db.copy_into(:test, columns: [:value, :name], data: ["1|firstname"])
+    expect(@db[:test].all.first.to_h).to eq({name: "firstname", value: 1})
+  end
+
+  specify "allows an options string to be appended" do
+    @db.copy_into(:test, data: ["lastname,2"], options: "DELIMITER ','")
+    expect(@db[:test].all.first.to_h).to eq({name: "lastname", value: 2})
+  end
+
+  specify "converts format: :csv to the correct SQL option" do
+    @db.copy_into(:test, data: ["lastname,2"], format: :csv)
+    expect(@db[:test].all.first.to_h).to eq({name: "lastname", value: 2})
   end
 end
 

--- a/spec/adapters/vertica_spec.rb
+++ b/spec/adapters/vertica_spec.rb
@@ -282,11 +282,13 @@ describe "Vertica::Database#copy_into" do
   end
 
   specify "errors if both a block and :data are specified" do
-    expect { @db.copy_into(:test, data: ["a string"]) { "a block" } }.to raise_error(ArgumentError)
+    expect { @db.copy_into(:test, data: ["a string"]) { "a block" } }.to \
+      raise_error(ArgumentError, "Cannot provide both a :data option and a block to copy_into")
   end
 
   specify "errors if neither block nor :data are specified" do
-    expect { @db.copy_into(:test) }.to raise_error(ArgumentError)
+    expect { @db.copy_into(:test) }.to \
+      raise_error(ArgumentError, "Must provide either a :data option or a block to copy_into")
   end
 
   specify "allows data columns to be specified" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ if ENV['SEQUEL_COLUMNS_INTROSPECTION']
 end
 
 
-Sequel.cache_anonymous_models = false
+Sequel::Model.cache_anonymous_models = false
 
 class Sequel::Database
   def log_duration(duration, message)


### PR DESCRIPTION
This PR updates sequel-vertica to be compliant with recent Sequel versions as of 4.49.

* As of Sequel 4.49 (starting probably somewhat earlier in the 4.x series),
  adapters appear to be expected to populate the columns cache (by setting
  self.columns) in the Dataset's fetch_rows() method.  This change conforms
  to that expectation, and also removes the sequel-vertica adapter's own
  cache of column attributes.
* Using `__` (double underscores) to separate schemas and tables (and columns) 
  is deprecated; use `Sequel[]` instead.
* `log_yield` is deprecated in favor of `log_connection_yield`
* We should now use the `#dataset_class_default` method to define which class to 
  use for a dataset, instead of relying on the framework to call `const_get("Dataset")` for us.
* A number of constants in Sequel::Dataset are now deprecated, and have been replaced
  with their previous values.
* `Sequel.cache_anonymous_models` has been moved to `Sequel::Model`